### PR TITLE
Make Airpark Drive physicsless

### DIFF
--- a/GameData/AirPark/Parts/Airpark_InfoDrive/Airpark_InfoDrive.cfg
+++ b/GameData/AirPark/Parts/Airpark_InfoDrive/Airpark_InfoDrive.cfg
@@ -36,6 +36,7 @@ PART
     angularDrag = 1
     crashTolerance = 9
     maxTemp = 2000 // = 3400
+    PhysicsSignificance = 1
 	bulkheadProfiles = srf
     tags = deploy direct science
 

--- a/LICENSE
+++ b/LICENSE
@@ -337,4 +337,3 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
-


### PR DESCRIPTION
I really enjoy the AirPark mod -- but I was surprised to note that the Airpark Drive part wasn't coded to be "physicsless" akin to the stock science experiment parts such as the thermometer or atmosphere analyzer, despite the fact that it is of comparable size, mass, and purpose.

I've added PhysicsSignificance = 1 to the Airpark part, which brings it in line with the stock low-mass parts, and should ever-so-slightly improve performance.